### PR TITLE
Add support for instantclick

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -163,7 +163,7 @@ archive_pagination: true
 category_pagination: true
 tag_pagination: true
 # Enable InstantClick
-instantclick: true
+instantclick: false
 
 
 # Integrated services

--- a/_config.yml
+++ b/_config.yml
@@ -162,6 +162,8 @@ image_gallery: true
 archive_pagination: true
 category_pagination: true
 tag_pagination: true
+# Enable InstantClick
+instantclick: true
 
 
 # Integrated services

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "fontawesome": "~4.3.0",
         "jquery":      "~2.1.3",
+        "instantclick":"~3.1.0",
         "fancybox":    "~2.1.5"
     }
 }

--- a/layout/_partial/script.ejs
+++ b/layout/_partial/script.ejs
@@ -3,7 +3,10 @@
 <%- js('assets/js/jquery.fancybox.js') %>
 <%- js('assets/js/jquery.fancybox-thumbs.js') %>
 <%- js('assets/js/tranquilpeak.js') %>
+<% if (theme.instantclick) { %>
 <%- js('assets/js/instantclick.min.js') %>
+<% } %>
+
 <!--SCRIPTS END-->
 <% if (theme.disqus_shortname && is_post() && post.comments) { %>
     <script type="text/javascript">

--- a/layout/_partial/script.ejs
+++ b/layout/_partial/script.ejs
@@ -3,6 +3,7 @@
 <%- js('assets/js/jquery.fancybox.js') %>
 <%- js('assets/js/jquery.fancybox-thumbs.js') %>
 <%- js('assets/js/tranquilpeak.js') %>
+<%- js('assets/js/instantclick.min.js') %>
 <!--SCRIPTS END-->
 <% if (theme.disqus_shortname && is_post() && post.comments) { %>
     <script type="text/javascript">
@@ -24,5 +25,22 @@
         })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
 
         _st('install','<%= theme.swiftype_install_key %>','2.0.0');
+    </script>
+<% } %>
+<% if (theme.instantclick) { %>
+    <script data-no-instant>
+    InstantClick.on('change', function(isInitialLoad) {
+      if (isInitialLoad === false) {
+        if (typeof MathJax !== 'undefined')     // MathJax compatibility
+          MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+        if (typeof prettyPrint !== 'undefined') // Google code prettify
+          prettyPrint();
+        if (typeof _hmt !== 'undefined')        // Baidu analytics
+          _hmt.push(['_trackPageview', location.pathname + location.search]);
+        if (typeof ga !== 'undefined')          // Google analytics
+            ga('send', 'pageview', location.pathname + location.search);
+      }
+    });
+    InstantClick.init();
     </script>
 <% } %>

--- a/layout/_partial/script.ejs
+++ b/layout/_partial/script.ejs
@@ -2,11 +2,8 @@
 <%- js('assets/js/jquery.js') %>
 <%- js('assets/js/jquery.fancybox.js') %>
 <%- js('assets/js/jquery.fancybox-thumbs.js') %>
+<%- js('assets/js/instantclick.js') %>
 <%- js('assets/js/tranquilpeak.js') %>
-<% if (theme.instantclick) { %>
-<%- js('assets/js/instantclick.min.js') %>
-<% } %>
-
 <!--SCRIPTS END-->
 <% if (theme.disqus_shortname && is_post() && post.comments) { %>
     <script type="text/javascript">

--- a/tasks/config/uglify.js
+++ b/tasks/config/uglify.js
@@ -6,6 +6,7 @@ module.exports = function(grunt) {
                 mangle: {
                     except: [
                         'jQuery',
+                        'InstantClick',
                         'fancybox'
                     ]
                 }

--- a/tasks/pipeline.js
+++ b/tasks/pipeline.js
@@ -3,6 +3,7 @@ var tranquilpeakJsFilesToInject = [
     'jquery.js',
     'jquery.fancybox.js',
     'jquery.fancybox-thumbs.js',
+    'instantclick.js',
     'tranquilpeak.js'
 ];
 


### PR DESCRIPTION
> [InstantClick](http://instantclick.io/) is a JavaScript library that dramatically speeds up your website, making navigation effectively instant in most cases.

In a word, it load the link when you move your mouse over it. Really fantastic.

* ~~There's a problem with search page, it doesn't appear(in fact when instantclick is disabled, it doesn't work as well, in my case).~~ (update: maybe because I forgot swiftype..)
* Disqus not tested, for my blog has not yet configured it.
* Google Analytics or other js's may need manual configuration.

So, currently by default it is disabled :stuck_out_tongue: But its really really great i hope it be a feature of the theme :+1: 