### PR TITLE
add disqus identifier for post

### DIFF
--- a/layout/_partial/script.ejs
+++ b/layout/_partial/script.ejs
@@ -9,7 +9,11 @@
         <script>
              var disqus_config = function () {
                  this.page.url = '<%= post.permalink %>';
-                 this.page.identifier = '<%= post.path %>';
+                 <% if (post.disqus_identifier) { %>
+                    this.page.identifier = '<%= post.disqus_identifier %>';
+                 <% } else { %>
+                    this.page.identifier = '<%= post.path %>';
+                 <% } %>                 
              };
             (function() {
                 var d = document, s = d.createElement('script');


### PR DESCRIPTION
Add possibility to use a [disqus identifier](https://help.disqus.com/customer/portal/articles/472099-what-is-a-disqus-identifier-) in a post