### PR TITLE
Use SPDX compatible license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "peak"
   ],
   "author": "Louis Barranqueiro",
-  "license": "GNU General Public License v3.0",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/issues"
   },


### PR DESCRIPTION
Newer npm versions give out a warning during package installation
if the license property is not a valid SPDX compatible license
identifier. Avoid this by defining a SPDX license identifier for the
license property.

Tested with npm v3.3.12
For more information see:
https://docs.npmjs.com/files/package.json#license