### PR TITLE
Added fallback monospace font

### DIFF
--- a/source/_css/utils/_variables.scss
+++ b/source/_css/utils/_variables.scss
@@ -5,7 +5,7 @@
 $open-sans:            'Open Sans';
 $open-sans-sans-serif: 'Open Sans', sans-serif;
 $merriweather-serif:   'Merriweather', serif;
-$menlo:                 Menlo;
+$menlo-monospace:       Menlo, monospace;
 
 $font-family-base: $open-sans-sans-serif;
 
@@ -13,14 +13,14 @@ $font-families: (
    // base
    'headings':          $open-sans-sans-serif,
    // components
-   'code':              $menlo,
+   'code':              $menlo-monospace,
    'caption':           $merriweather-serif,
    'image-gallery':     $open-sans,
    'post-header-cover': $merriweather-serif,
    'post-meta':         $open-sans-sans-serif,
    'post-content':      $merriweather-serif,
    'post-excerpt-link': $open-sans-sans-serif,
-   'highlight':         $menlo,
+   'highlight':         $menlo-monospace,
    // layout
    'sidebar':           $open-sans-sans-serif
 );


### PR DESCRIPTION
I suggest that you add a default fallback for the monospace font, since if you don't have the Menlo font installed, it will use the default (in my case serif) font instead of a monospace font for code blocks.