### PR TITLE
Update zh-cn.yml, zh-tw.yml

### DIFF
--- a/languages/zh-cn.yml
+++ b/languages/zh-cn.yml
@@ -25,17 +25,17 @@ global:
     search_tag: "搜索标签"
     search_date: "搜索日期 (YYYY/MM/DD)"
     posts_found:
-        zero: "没有发现帖子"
-        one: "发现后"
-        other: "发现帖子"
+        zero: "0 篇文章"
+        one: " 篇文章"
+        other: "0 篇文章"
     categories_found:
-        zero: "没有找到类别"
-        one: "发现类"
-        other: "发现类别"
+        zero: "0 个分类"
+        one: " 个分类"
+        other: " 个分类"
     tags_found:
-        zero: "没有发现标签"
-        one: "标签发现"
-        other: "发现标签"
+        zero: "0 个标签"
+        one: " 个标签"
+        other: " 个标签"
 
 
 pagination:

--- a/languages/zh-tw.yml
+++ b/languages/zh-tw.yml
@@ -25,17 +25,17 @@ global:
     search_tag: "搜尋標籤"
     search_date: "搜尋日期（YYYY/MM/DD）"
     posts_found:
-        zero: "無後發現"
-        one: "發現後"
-        other: "發現帖子"
+        zero: "0 篇文章"
+        one: " 篇文章"
+        other: " 篇文章"
     categories_found:
-        zero: "沒有找到類別"
-        one: "發現類"
-        other: "發現類別"
+        zero: "0 個分類"
+        one: " 個分類"
+        other: " 個分類"
     tags_found:
-        zero: "沒有發現標籤"
-        one: "標籤發現"
-        other: "發現標籤"
+        zero: "0 個標籤"
+        one: " 個標籤"
+        other: " 個標籤"
 
 pagination:
     page: "第 %d 頁"


### PR DESCRIPTION
(workaround)

Note: currently because of the implementation of the filters ( see comments [in here](https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/commit/819b33d93a68e707d62bb03760f67231fba8a6c7)), we cannot use the strings such as `发现 %d 篇文章`, `發現 %d 個標籤`.

ref: [categories-filter.js](https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/blob/819b33d93a68e707d62bb03760f67231fba8a6c7/source/_js/categories-filter.js#L78-L88)