### PR TITLE
Typo on class name

### DIFF
--- a/layout/_partial/index.ejs
+++ b/layout/_partial/index.ejs
@@ -70,7 +70,7 @@
                 <%- partial('post/meta', {post: post, classes: ['postShorten-meta']}) %>
             </div>
             <% if (thumbnailImageUrl !== null && thumbnailImagePosition === "bottom") { %>
-                <div class="postShorten-thumbnailimg postShorten-thumbnailimg--bottom">
+                <div class="postShorten-thumbnailimg postShorten--thumbnailimg-bottom">
                     <img alt="" itemprop="image" src="<%= thumbnailImageUrl %>"/>
                 </div>
                 <% thumbnailImageUrl = null; %>


### PR DESCRIPTION
Fix typo on class name in order to correctly match

https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/blob/dev/source/_css/components/_postShorten.scss#L127