### PR TITLE
fix HTML5 time tag validation error

### DIFF
--- a/layout/_partial/post/meta.ejs
+++ b/layout/_partial/post/meta.ejs
@@ -1,5 +1,5 @@
 <div class="<%= (classes ? classes.join(' ') : '') %>">
-    <time itemprop="datePublished" content="<%= post.date %>">
+    <time itemprop="datePublished" datetime="<%= post.date.format() %>">
 	<% if (post.lang) { %>
 		    <%= post.date.locale(post.lang).format(__('date_format')) %>
     	<% } else { %>


### PR DESCRIPTION
@LouisBarranqueiro here is another HTML5 bug fix

fix HTML5 time tag validation error: attribute content not allowed on element time at this point