### PR TITLE
HTML5: Google rel="publisher" shall be link tag

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -118,7 +118,7 @@
         fb_app_id: theme.fb_app_id
     }) %>
     <% if (theme.author.google_plus) { %>
-        <meta rel="publisher" content="https://plus.google.com/<%= theme.author.google_plus %>"/>
+        <link rel="publisher" content="https://plus.google.com/<%= theme.author.google_plus %>"/>
     <% } %>
     <% if (typeof fb_admin_ids !== 'undefined') { %>
         <% fb_admin_ids.forEach(function(fb_admin_id) { %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -118,7 +118,7 @@
         fb_app_id: theme.fb_app_id
     }) %>
     <% if (theme.author.google_plus) { %>
-        <link rel="publisher" content="https://plus.google.com/<%= theme.author.google_plus %>"/>
+        <link rel="publisher" href="https://plus.google.com/<%= theme.author.google_plus %>"/>
     <% } %>
     <% if (typeof fb_admin_ids !== 'undefined') { %>
         <% fb_admin_ids.forEach(function(fb_admin_id) { %>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : Ubuntu (doesn´t matter)
 - **Node version** :  4.4.3 (doesn´t matter)
 - **Hexo version** :  3.2.0 (doesn´t matter)
 - **Hexo-cli version** : --
 
### Changes proposed

 -  Change <meta rel="publisher"> to <link rel="publisher"> to avoid HTML 5 validation errors.

Actual Google rel="publisher" is generated as <meta> tag. This causes
errors in HTML5 validation because <meta> has no attribute "rel" and
also, <meta> shall have a name, itemprop, property or http-equive
attributes.

Changing it to <link> tag solves these validations errors and makes
Google rich snippets work. It is important to notice that rel="publisher"
is meant to link a Google+ business page and not to individuals G+ page.

ToDo:
I don´t know if this affects or not the result but for future we shall
think in have a 'business' property in theme _config.yml and author 
property as already set. Then we might create rel="publisher" 
pointing to the business and rel="author" linking to author´s G+ page.

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>