### PR TITLE
HTML5 validator: Stray start tag `<script>`

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -34,6 +34,6 @@
         </div>
         <%- partial('_partial/about', null, {cache: !config.relative_link}) %>
         <%- partial('_partial/cover', null, {cache: !config.relative_link}) %>
+        <%- partial('_partial/script', {post: page}) %>
     </body>
-    <%- partial('_partial/script', {post: page}) %>
 </html>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : Ubuntu 14.04
 - **Node version** : 4.4.3
 - **Hexo version** :  3.2.0
 - **Hexo-cli version** : 
 
### Changes proposed

 - HTML5 validation complains about stray start tag `<string>`, this means `<string>` tag is out of page´s body (after `</body>` tag)
 
HTML validation shows that `<script>` tag is after `</body>`. This fixes
it by put scripts inside the body.

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>