### PR TITLE
Google rel="publisher" shall be link tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -121,8 +121,12 @@ author:
     picture:
     # Your Twitter username without the @. E.g : `tranquilpeak`
     twitter:
-    # Your google plus profile id. E.g : `+Tranquilpeak` or `123812884128439`
+    # Your personal google plus profile id, not your blog or business page id.
+    # E.g : `+JohnDoe` or `123812884128439`
     google_plus:
+    # Your businnes google plus profile id. If not provided, personal will be used instead.
+    # E.g : `+Tranquilpeak` or `123812884128439`
+    google_plus_business:
 
 
 # Customization

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -20,7 +20,7 @@
      */
     (function() {
         if (theme.author.google_plus_business) {
-            publisher = theme.author.google_plus;
+            publisher = theme.author.google_plus_business;
         }
         else if (theme.author.google_plus) {
             publisher = theme.author.google_plus;
@@ -130,7 +130,7 @@
         twitter_id: theme.author.twitter,
         fb_app_id: theme.fb_app_id
     }) %>
-    <% if (publisher != '') { %>
+    <% if (publisher) { %>
         <link rel="publisher" href="https://plus.google.com/<%= publisher %>"/>
     <% } %>
     <% if (typeof fb_admin_ids !== 'undefined') { %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -118,7 +118,7 @@
         fb_app_id: theme.fb_app_id
     }) %>
     <% if (theme.author.google_plus) { %>
-        <meta rel="publisher" content="https://plus.google.com/<%= theme.author.google_plus %>"/>
+        <link rel="publisher" href="https://plus.google.com/<%= theme.author.google_plus %>"/>
     <% } %>
     <% if (typeof fb_admin_ids !== 'undefined') { %>
         <% fb_admin_ids.forEach(function(fb_admin_id) { %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -4,6 +4,7 @@
     var fb_admin_ids = [];
     var keywords = '';
     var photos = [];
+    var publisher = '';
 
     /**
      * Separate fb admin ids
@@ -11,6 +12,18 @@
     (function() {
         if (theme.fb_admin_ids) {
             fb_admin_ids = String(theme.fb_admin_ids).split(',');
+        }
+    })();
+
+    /**
+     * Pick publisher G+ profile
+     */
+    (function() {
+        if (theme.author.google_plus_business) {
+            publisher = theme.author.google_plus;
+        }
+        else if (theme.author.google_plus) {
+            publisher = theme.author.google_plus;
         }
     })();
 
@@ -117,8 +130,8 @@
         twitter_id: theme.author.twitter,
         fb_app_id: theme.fb_app_id
     }) %>
-    <% if (theme.author.google_plus) { %>
-        <link rel="publisher" href="https://plus.google.com/<%= theme.author.google_plus %>"/>
+    <% if (publisher != '') { %>
+        <link rel="publisher" href="https://plus.google.com/<%= publisher %>"/>
     <% } %>
     <% if (typeof fb_admin_ids !== 'undefined') { %>
         <% fb_admin_ids.forEach(function(fb_admin_id) { %>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : Ubuntu (doesn´t matter)
 - **Node version** :  4.4.3 (doesn´t matter)
 - **Hexo version** :  3.2.0 (doesn´t matter)
 - **Hexo-cli version** : --
 
### Changes proposed

 -  Change <meta rel="publisher"> to <link rel="publisher"> to avoid HTML 5 validation errors.

Actual Google rel="publisher" is generated as <meta> tag. This causes
errors in HTML5 validation because <meta> has no attribute "rel" and
also, <meta> shall have a name, itemprop, property or http-equive
attributes. Changing it to <link> tag solves these validations errors.
It is important to notice that rel="publisher" is meant to link a Google+ 
business page and not to individuals G+ page. So a new property was 
created to hold G+ business page and put it in this tag if available.

Notice: This is compatible with old behavior since if no business page is provided the personal business page is linked as before. No functionality break.

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>