### PR TITLE
Sidebar: Add rel="me" property to profile´s <a> links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,31 +57,39 @@ sidebar:
             title: global.about
             url: /#about
             icon: question
+            # me: is used to determine if this is a link to a personal (author) profile (not blog page or business page)
+            me: true
     author_links:
         # github:
         #     title: global.github
         #     url: https://github.com/
         #     icon: github
+        #     me: true
         # stack_overflow:
         #     title: global.stack_overflow
         #     url: http://stackoverflow.com/users
         #     icon: stack-overflow
+        #     me: true
         # twitter:
         #     title: global.twitter
         #     url: https://twitter.com/
         #     icon: twitter
+        #     me: true
         # facebook:
         #     title: global.facebook
         #     url: https://facebook.com/
         #     icon: facebook
+        #     me: true
         # google_plus:
         #     title: global.google_plus
         #     url: https://plus.google.com/
         #     icon: google-plus
+        #     me: true
         # linked_in:
         #     title: global.linkedin
         #     url: https://www.linkedin.com/profile/
         #     icon: linkedin
+        #     me: true
         # mail:
         #     title: global.mail
         #     url: mailto:

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -1,14 +1,17 @@
 <!-- Define author's picture -->
-<% var authorPicture = null; %>
-<% if (theme.gravatar_email && theme.gravatar_email.length) { %>
-    <% authorPicture = gravatar(theme.gravatar_email, 110); %>
-<% } else if (theme.author.picture && theme.author.picture.length) { %>
-<% if (is_remote_url(theme.author.picture)) { %>
-        <% authorPicture = theme.author.picture; %>
-    <% } else { %>
-        <% authorPicture = url_for(theme.image_dir + '/' + theme.author.picture); %>
-    <% } %>
-<% } %>
+<% 
+	var authorPicture = null;
+
+	if (theme.gravatar_email && theme.gravatar_email.length) { 
+		authorPicture = gravatar(theme.gravatar_email, 110); 
+	} else if (theme.author.picture && theme.author.picture.length) { 
+		if (is_remote_url(theme.author.picture)) { 
+			authorPicture = theme.author.picture; 
+		} else { 
+			authorPicture = url_for(theme.image_dir + '/' + theme.author.picture); 
+		} 
+	} 
+%>
 <nav id="sidebar" data-behavior="<%= sidebarBehavior %>">
     <% if (authorPicture) { %>
         <div class="sidebar-profile">

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -15,7 +15,7 @@
 <nav id="sidebar" data-behavior="<%= sidebarBehavior %>">
     <% if (authorPicture) { %>
         <div class="sidebar-profile">
-            <a href="<%- url_for('/#about') %>">
+            <a rel="me" href="<%- url_for('/#about') %>">
                     <img class="sidebar-profile-picture" src="<%= authorPicture %>"/>
             </a>
             <span class="sidebar-profile-name"><%= config.author %></span>
@@ -26,13 +26,15 @@
         <% for (var n in theme.sidebar[i]) { %>
             <li class="sidebar-button">
                 <% if (url_for(theme.sidebar[i][n].url).indexOf(config.url) < 0 && url_for(theme.sidebar[i][n].url).indexOf(':') >= 0) { %>
-                    <a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>" href="<%- url_for(theme.sidebar[i][n].url) %>" target="_blank">
+			<a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>"
+			    <% if (theme.sidebar[i][n].me) {%> rel="me" <%}%> href="<%- url_for(theme.sidebar[i][n].url) %>" target="_blank">
                 <% } else { %>
-                    <a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>"
-                        <% if (theme.sidebar[i][n].url.indexOf("/") === 0 && theme.sidebar[i][n].url.length === 1) { %> href="<%- url_for(' ') %>"
-                        <% } else if (theme.sidebar[i][n].url.indexOf("/") === 0) { %> href="<%- url_for(theme.sidebar[i][n].url.substr(1)) %>"
-                        <% } else { %> href="<%- url_for(theme.sidebar[i][n].url) %>"<% } %>
-                    >
+			<a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>"
+			    <% if (theme.sidebar[i][n].me) {%> rel="me" <%}%> 
+                            <% if (theme.sidebar[i][n].url.indexOf("/") === 0 && theme.sidebar[i][n].url.length === 1) { %> href="<%- url_for(' ') %>"
+                            <% } else if (theme.sidebar[i][n].url.indexOf("/") === 0) { %> href="<%- url_for(theme.sidebar[i][n].url.substr(1)) %>"
+                            <% } else { %> href="<%- url_for(theme.sidebar[i][n].url) %>"<% } %>
+                        >
                 <% } %>
                     <i class="sidebar-button-icon fa fa-lg <%= 'fa-' + theme.sidebar[i][n].icon %>"></i>
                     <span class="sidebar-button-desc"><%= __(theme.sidebar[i][n].title) %></span>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration
- **Operating system with version** : Ubuntu
- **Node version** : 4.4.3
- **Hexo version** :  3.2.0
- **Hexo-cli version** : -
### Changes proposed
- This patch adds `rel="me"` property  to every <a> tag that links to a profile in another service (github, stackoverflow, etc...). In this patch the property `rel="me"` is conditionally added to profile link tags in the sidebar. Condition to determine if property is add or not is defined in the sidebar configuration (`_config.yml`).

The property `rel="me"` is used to establish a relation between profile pages. It indicates that page being linked refers to the same page as this one. If the linked page also link back with `rel="me"` property then crawler can close the loop and consider both profiles as one single person.

Sites like Twitter, Stackoverflow, Pinterest, Github, etc, all present a `rel="me"` property in the links to external pages in the user profile. Hence we shall link back.
