### PR TITLE
Change header-title from h1 to div

### DIFF
--- a/layout/_partial/about.ejs
+++ b/layout/_partial/about.ejs
@@ -17,23 +17,23 @@
         <% if (authorPicture) { %>
             <img id="about-card-picture" src="<%= authorPicture %>"/>
         <% } %>
-            <h4 id="about-card-name"><%= config.author %></h4>
+            <div id="about-card-name"><%= config.author %></div>
         <% if (__('author.bio')) { %>
-            <h5 id="about-card-bio"><%- markdown(__('author.bio')) %></h5>
+            <div id="about-card-bio"><%- markdown(__('author.bio')) %></div>
         <% } %>
         <% if (__('author.job')) { %>
-            <h5 id="about-card-job">
+            <div id="about-card-job">
                 <i class="fa fa-briefcase"></i>
                 <br/>
                 <%- markdown(__('author.job')) %>
-            </h5>
+            </div>
         <% } %>
         <% if (theme.author.location) { %>
-            <h5 id="about-card-location">
+            <div id="about-card-location">
                 <i class="fa fa-map-marker"></i>
                 <br/>
                 <%= theme.author.location %>
-            </h5>
+            </div>
         <% } %>
     </div>
 </div>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -13,9 +13,9 @@
 <% } %>
 <header id="header" data-behavior="<%= sidebarBehavior %>">
     <i id="btn-open-sidebar" class="fa fa-lg fa-bars"></i>
-    <h1 class="header-title">
+    <div class="header-title">
         <a class="header-title-link" href="<%- url_for(' ') %>"><%= config.title %></a>
-    </h1>
+    </div>
     <% if (theme.header && theme.header.right_link) { %>
         <% if (theme.header.right_link.url && url_for(theme.header.right_link.url).indexOf(config.url) < 0 && url_for(theme.header.right_link.url).indexOf(':') >= 0) { %>
             <a  class="<%= (theme.header.right_link.icon ? 'header-right-icon ' : 'header-right-picture ') %><% if (theme.header.right_link.class) { %><%= theme.header.right_link.class %><% } %>"

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -34,6 +34,6 @@
         </div>
         <%- partial('_partial/about', null, {cache: !config.relative_link}) %>
         <%- partial('_partial/cover', null, {cache: !config.relative_link}) %>
+        <%- partial('_partial/script', {post: page}) %>
     </body>
-    <%- partial('_partial/script', {post: page}) %>
 </html>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : Microsoft Windows [Version 10.0.10586]
 - **Node version** : 6.3.0
 - **Hexo version** : 3.2.2
 - **Hexo-cli version** : 
 
### Changes proposed

 - Change header-title from h1 to div to prevent HTML5 validator warning and to improve SEO ![h1](https://cloud.githubusercontent.com/assets/6225870/16712151/43d860b0-4686-11e6-93ba-6573a405efce.PNG)
 - Change headings to divs to prevent HTML5 validation errors ![about](https://cloud.githubusercontent.com/assets/6225870/16712211/a3e78b50-4688-11e6-95de-06e191f1f985.PNG)
 - Move scripts to be inside BODY 
![scripts](https://cloud.githubusercontent.com/assets/6225870/16712328/cd698ce0-468c-11e6-8ca1-3de1b6448bdf.PNG)

