### PR TITLE
Add a fallback monospace font for when Menlo is not installed.

### DIFF
--- a/source/_css/utils/_variables.scss
+++ b/source/_css/utils/_variables.scss
@@ -5,7 +5,7 @@
 $open-sans:            'Open Sans';
 $open-sans-sans-serif: 'Open Sans', sans-serif;
 $merriweather-serif:   'Merriweather', serif;
-$menlo:                 Menlo;
+$menlo:                 Menlo, monospace;
 
 $font-family-base: $open-sans-sans-serif;
 


### PR DESCRIPTION
`Menlo` is not installed by default on many operating systems. I've added `monospace` as a fallback option so that a monospace font is used as an alternative.

This should fix #286 as Windows 10 will no longer use a serif font to display the code.