### PR TITLE
Add fallback monospace fonts for when Menlo is not installed.

### DIFF
--- a/source/_css/utils/_variables.scss
+++ b/source/_css/utils/_variables.scss
@@ -5,7 +5,7 @@
 $open-sans:            'Open Sans';
 $open-sans-sans-serif: 'Open Sans', sans-serif;
 $merriweather-serif:   'Merriweather', serif;
-$menlo:                 Menlo;
+$monospace:             Menlo, Consolas, monospace;
 
 $font-family-base: $open-sans-sans-serif;
 
@@ -13,14 +13,14 @@ $font-families: (
    // base
    'headings':          $open-sans-sans-serif,
    // components
-   'code':              $menlo,
+   'code':              $monospace,
    'caption':           $merriweather-serif,
    'image-gallery':     $open-sans,
    'post-header-cover': $merriweather-serif,
    'post-meta':         $open-sans-sans-serif,
    'post-content':      $merriweather-serif,
    'post-excerpt-link': $open-sans-sans-serif,
-   'highlight':         $menlo,
+   'highlight':         $monospace,
    // layout
    'sidebar':           $open-sans-sans-serif
 );


### PR DESCRIPTION
Menlo is not installed by default on many operating systems. This should fix #286 