### PR TITLE
remove autofocus attribute of search fields

### DIFF
--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -10,7 +10,7 @@
             <form id="algolia-search-form">
                 <input type="text" id="algolia-search-input" name="search"
                     class="form-control input--large search-input" placeholder="Search "
-                    autofocus="autofocus"/>
+                    />
             </form>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->

The attribute "autofocus" cause Firefox to scroll down. Since we have already set focus on the text field when we open the search modal, we don't need "autofocus" attribute any more. This should fix issue #316.