### PR TITLE
fix issue #344

### DIFF
--- a/source/_js/search-modal.js
+++ b/source/_js/search-modal.js
@@ -33,8 +33,9 @@
       // open modal when `s` button is pressed
       $(document).keyup(function(event) {
         var target = event.target || event.srcElement;
-        // exit if user is focusing an input
-        if (target.tagName.toUpperCase() === 'INPUT') {
+        // exit if user is focusing an input or textarea
+        var tagName = target.tagName.toUpperCase();
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
           return;
         }
 


### PR DESCRIPTION
when type 's' in textarea (some comment plugin use textarea tag), the search modal will show.
https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/issues/334
