### PR TITLE
Add print media queries

### DIFF
--- a/source/_css/components/_post-actions.scss
+++ b/source/_css/components/_post-actions.scss
@@ -81,3 +81,10 @@
         }
     }
 }
+
+// Hide post actions in print layout
+@media print {
+    .post-actions-wrap {
+        display: none;
+    }
+}

--- a/source/_css/components/_share-options-bar.scss
+++ b/source/_css/components/_share-options-bar.scss
@@ -109,3 +109,10 @@
         }
     }
 }
+
+// Hide share options in print layout
+@media print {
+    .share-options-bar {
+        display: none;
+    }
+}

--- a/source/_css/layouts/_header.scss
+++ b/source/_css/layouts/_header.scss
@@ -110,3 +110,10 @@
         }
     }
 }
+
+// Hide header in print layout
+@media print {
+    #header {
+        display: none;
+    }
+}

--- a/source/_css/layouts/_sidebar.scss
+++ b/source/_css/layouts/_sidebar.scss
@@ -166,3 +166,10 @@
         display: none;
     }
 }
+
+// Hide sidebar in print layout
+@media print {
+    #sidebar {
+        display: none;
+    }
+}


### PR DESCRIPTION
### Configuration

 - **Operating system with version** : Windows 7
 - **Node version** : 6.9.1
 - **Hexo version** : 3.2.2
 - **Hexo-cli version** : 1.0.2
 
### Changes proposed

The Tranquilpeak theme doesn't include a print media query, which is used both for actually printing a blog post and saving it as PDF.

This PR hides the following elements when printing the page: sidebar, header, post actions, share options

**Before:**

![print-before](https://cloud.githubusercontent.com/assets/3101914/21933488/ea30d4d0-d9a5-11e6-93cd-75cab8e2b118.png)

**After:**

![print-after](https://cloud.githubusercontent.com/assets/3101914/21933496/f1775f52-d9a5-11e6-9279-8e831709d55a.png)
