### PR TITLE
Add rel="noopener" when using target="_blank"

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -19,7 +19,7 @@
     <% if (theme.header && theme.header.right_link) { %>
         <% if (theme.header.right_link.url && url_for(theme.header.right_link.url).indexOf(config.url) < 0 && url_for(theme.header.right_link.url).indexOf(':') >= 0) { %>
             <a  class="<%= (theme.header.right_link.icon ? 'header-right-icon ' : 'header-right-picture ') %><% if (theme.header.right_link.class) { %><%= theme.header.right_link.class %><% } %>"
-                href="<%- url_for(theme.header.right_link.url) %>" target="_blank">
+                href="<%- url_for(theme.header.right_link.url) %>" target="_blank" rel="noopener">
         <% } else if (theme.header.right_link.url) { %>
             <a  class="<%= (theme.header.right_link.icon ? 'header-right-icon ' : 'header-right-picture ') %><% if (theme.header.right_link.class) { %><%= theme.header.right_link.class %><% } %>"
                 href="<% if (theme.header.right_link.url.indexOf("/") === 0) { %><%- url_for(theme.header.right_link.url.substr(1)) %><% } else { %><%- url_for(theme.header.right_link.url) %><% } %>">

--- a/layout/_partial/post/header.ejs
+++ b/layout/_partial/post/header.ejs
@@ -1,7 +1,7 @@
 <div class="post-header main-content-wrap <%= (post.metaAlignment ? 'text-' + post.metaAlignment : 'text-left') %>">
     <% if (post.link) { %>
         <h1 itemprop="headline">
-            <a class="link" href="<%- url_for(post.link) %>" target="_blank" itemprop="url">
+            <a class="link" href="<%- url_for(post.link) %>" target="_blank" rel="noopener" itemprop="url">
                 <%= post.title || '(' + __('post.no_title') + ')' %>
             </a>
         </h1>

--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -2,7 +2,7 @@
     <div class="modal">
         <div class="modal-header">
             <span class="close-button"><i class="fa fa-close"></i></span>
-            <a href="https://algolia.com" target="_blank" class="searchby-algolia text-color-light link-unstyled">
+            <a href="https://algolia.com" target="_blank" rel="noopener" class="searchby-algolia text-color-light link-unstyled">
                 <span class="searchby-algolia-text text-color-light text-small">by</span>
                 <img class="searchby-algolia-logo" src="https://www.algolia.com/static_assets/images/press/downloads/algolia-light.svg">
             </a>

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -27,7 +27,7 @@
             <% for (var n in theme.sidebar[i]) { %>
                 <li class="sidebar-button">
                     <% if (url_for(theme.sidebar[i][n].url).indexOf(config.url) < 0 && url_for(theme.sidebar[i][n].url).indexOf(':') >= 0) { %>
-                        <a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>" href="<%- url_for(theme.sidebar[i][n].url) %>" target="_blank">
+                        <a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>" href="<%- url_for(theme.sidebar[i][n].url) %>" target="_blank" rel="noopener">
                     <% } else { %>
                         <a  class="sidebar-button-link <% if (theme.sidebar[i][n].class) { %><%= theme.sidebar[i][n].class %><% } %>"
                             <% if (theme.sidebar[i][n].url.indexOf("/") === 0 && theme.sidebar[i][n].url.length === 1) { %> href="<%- url_for(' ') %>"


### PR DESCRIPTION
### Configuration

 - **Operating system with version** : Windows 7
 - **Node version** : 6.9.1
 - **Hexo version** : 3.2.2
 - **Hexo-cli version** : 1.0.2
 
### Changes proposed

It's a good practice to add `rel="noopener"` when using `target="_blank"` to both [improve performance](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/) and [prevent security vulnerabilities](https://mathiasbynens.github.io/rel-noopener/).