### PR TITLE
comment_and_share should be translated to "评论和共享" in Chinese.

### DIFF
--- a/languages/zh-cn.yml
+++ b/languages/zh-cn.yml
@@ -54,7 +54,7 @@ post:
     toc: "目录"
     read_more: "阅读全文"
     go_to_website: "转到"
-    comment_and_share: "注释和共享"
+    comment_and_share: "评论和共享"
 
 author:
     # 你的个人简介 (支持 Markdown 和 HTML 语法)


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : 
 - **Node version** : 
 - **Hexo version** : 
 - **Hexo-cli version** : 
 
### Changes proposed

 - the wrong translation of 'comment_and_share' in Chinese


