### PR TITLE
Add front-matter options to hide post meta and actions.

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -612,6 +612,8 @@ gallery:
     - http://i.imgur.com/o9r19kD.jpg "Dubai"
     - https://example.com/orignal.jpg https://example.com/thumbnail.jpg "Sidney"
 comments: false
+hideMeta: true
+hideActions: true
 ```
 
 |Variable|Description|
@@ -628,7 +630,9 @@ comments: false
 |coverCaption|Add a caption under the cover image : [Cover caption demo](http://louisbarranqueiro.github.io/hexo-theme-tranquilpeak/2015/05/13/Cover-image-showcase/)|
 |coverMeta|`in`: display post meta (title, date and categories) on cover image, `out`: display meta (title, date and categories) under cover image as usual. Default behavior : `in`|
 |gallery|Formerly **photos**. Images displayed in an image gallery (with fancybox) at the end of the post. If thumbnail image is not configured and cover image too, the first photo is used as thumbnail image. format: `original url [thumbnail url] [caption]`, E.g : `https://example.com/original.jpg https://example.com/thumbnail.jpg "New York"`|
-|comments|Disable the comment of the post.
+|comments|Disable the comment of the post.|
+|hideMeta|Hide post meta (date, categories).|
+|hideActions|Hide post actions (navigation, share links).|
 
 Example: 
 A post on index page will look like this with :`thumbnailImagePosition` set to `bottom`:  
@@ -798,7 +802,26 @@ E.g : `{% wide_image http://google.fr/images/image125.png "A beautiful sunrise" 
 #### Fancybox
 
 `fancybox` tag is deprecated since Tranquilpeak 1.3. Please use `image` tag with `fancybox` class to generate them. More information here : [Image tag](#image) 
-  
+
+### Custom 404 error page
+
+When a user requests a page that the server cannot find, a standard *404* error page will be displayed. To create a custom 404 page that fits the theme first create a `404.md` file in your Hexo `source` folder. 
+
+Hide post meta, actions and comments using front-matter settings:
+
+``` yaml
+title: Page not found
+hideMeta: true
+hideActions: true
+comments: false
+```
+
+Now you can customize your 404 error page just like any other blog post.
+Finally, you need to tell your server to use `/404.html` (which Hexo generates out of `404.md`) as your default 404 error page. Here are tutorials for the most common web servers:
+
+ - [Apache](https://www.digitalocean.com/community/tutorials/how-to-create-a-custom-404-page-in-apache)
+ - [Nginx](https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-to-use-custom-error-pages-on-ubuntu-14-04)
+
 ## Running ##
 
 Run `hexo server` and start writing! :)

--- a/docs/user.md
+++ b/docs/user.md
@@ -612,8 +612,8 @@ gallery:
     - http://i.imgur.com/o9r19kD.jpg "Dubai"
     - https://example.com/orignal.jpg https://example.com/thumbnail.jpg "Sidney"
 comments: false
-hideMeta: true
-hideActions: true
+meta: false
+actions: false
 ```
 
 |Variable|Description|
@@ -631,8 +631,8 @@ hideActions: true
 |coverMeta|`in`: display post meta (title, date and categories) on cover image, `out`: display meta (title, date and categories) under cover image as usual. Default behavior : `in`|
 |gallery|Formerly **photos**. Images displayed in an image gallery (with fancybox) at the end of the post. If thumbnail image is not configured and cover image too, the first photo is used as thumbnail image. format: `original url [thumbnail url] [caption]`, E.g : `https://example.com/original.jpg https://example.com/thumbnail.jpg "New York"`|
 |comments|Disable the comment of the post.|
-|hideMeta|Hide post meta (date, categories).|
-|hideActions|Hide post actions (navigation, share links).|
+|meta|Disable post meta (date, categories).|
+|actions|Disable post actions (navigation, share links).|
 
 Example: 
 A post on index page will look like this with :`thumbnailImagePosition` set to `bottom`:  
@@ -805,22 +805,24 @@ E.g : `{% wide_image http://google.fr/images/image125.png "A beautiful sunrise" 
 
 ### Custom 404 error page
 
-When a user requests a page that the server cannot find, a standard *404* error page will be displayed. To create a custom 404 page that fits the theme first create a `404.md` file in your Hexo `source` folder. 
+When a user requests a page that the server cannot find, a standard *404* error page will be displayed. To create a custom 404 page that fits the theme first create a `404.md` file in your Hexo `source` folder.
 
 Hide post meta, actions and comments using front-matter settings:
 
 ``` yaml
 title: Page not found
-hideMeta: true
-hideActions: true
+meta: false
+actions: false
 comments: false
 ```
 
 Now you can customize your 404 error page just like any other blog post.
-Finally, you need to tell your server to use `/404.html` (which Hexo generates out of `404.md`) as your default 404 error page. Here are tutorials for the most common web servers:
+Finally, you need to tell your server to use `/404.html` (which Hexo generates out of `404.md`) as your default 404 error page. Here are tutorials for some common web servers/providers:
 
  - [Apache](https://www.digitalocean.com/community/tutorials/how-to-create-a-custom-404-page-in-apache)
  - [Nginx](https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-to-use-custom-error-pages-on-ubuntu-14-04)
+ - [GitHub Pages](https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/)
+ - [Amazon Cloudfront/S3](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html)
 
 ## Running ##
 

--- a/layout/_partial/post.ejs
+++ b/layout/_partial/post.ejs
@@ -40,7 +40,7 @@
                 <%- partial('post/tag', {tags: post.tags})%>
             </div>
         <% } %>
-        <% if (!post.hideActions) { %>
+        <% if (post.actions === undefined || post.actions) { %>
             <%- partial('post/actions', {postContent: postContent}) %>
         <% } %>
         <% if (post.comments) { %>

--- a/layout/_partial/post.ejs
+++ b/layout/_partial/post.ejs
@@ -40,7 +40,9 @@
                 <%- partial('post/tag', {tags: post.tags})%>
             </div>
         <% } %>
-        <%- partial('post/actions', {postContent: postContent}) %>
+        <% if (!post.hideActions) { %>
+            <%- partial('post/actions', {postContent: postContent}) %>
+        <% } %>
         <% if (post.comments) { %>
             <% if (theme.disqus_shortname) { %>
                 <%- partial('post/disqus') %>

--- a/layout/_partial/post/header.ejs
+++ b/layout/_partial/post/header.ejs
@@ -10,7 +10,7 @@
             <%= post.title || '(' + __('post.no_title') + ')' %>
         </h1>
     <% } %>
-    <% if (!post.hideMeta) { %>
+    <% if (post.meta === undefined || post.meta) { %>
         <%- partial('meta',{classes: ['post-meta']}) %>
     <% } %>
 </div>

--- a/layout/_partial/post/header.ejs
+++ b/layout/_partial/post/header.ejs
@@ -10,5 +10,7 @@
             <%= post.title || '(' + __('post.no_title') + ')' %>
         </h1>
     <% } %>
-    <%- partial('meta',{classes: ['post-meta']}) %>
+    <% if (!post.hideMeta) { %>
+        <%- partial('meta',{classes: ['post-meta']}) %>
+    <% } %>
 </div>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -25,7 +25,7 @@
                 <%- body %>
                 <%- partial('_partial/footer', null, {cache: !config.relative_link}) %>
             </div>
-            <% if (is_post()) { %>
+            <% if (is_post() && !post.hideActions) { %>
                 <div id="bottom-bar" class="post-bottom-bar" data-behavior="<%= sidebarBehavior %>">
                     <%- partial('_partial/post/actions', {post: page}) %>
                 </div>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -25,7 +25,7 @@
                 <%- body %>
                 <%- partial('_partial/footer', null, {cache: !config.relative_link}) %>
             </div>
-            <% if (is_post() && !post.hideActions) { %>
+            <% if (is_post() && (page.actions === undefined || page.actions)) { %>
                 <div id="bottom-bar" class="post-bottom-bar" data-behavior="<%= sidebarBehavior %>">
                     <%- partial('_partial/post/actions', {post: page}) %>
                 </div>


### PR DESCRIPTION
This makes custom 404 error pages look more clean (#327).

### Configuration

 - **Operating system with version** : 
 - **Node version** : 6.9.1
 - **Hexo version** : 3.2.0
 - **Hexo-cli version** :  1.0.2
 
### Changes proposed

 - Front-matter options to hide post meta and actions.