### PR TITLE
Fix error after adding it-IT.yml file (#375)

### DIFF
--- a/languages/it-IT.yml
+++ b/languages/it-IT.yml
@@ -57,6 +57,6 @@ post:
 
 author:
     # LA tua biografia (Markdown e HTML sono supportati)
-    bio:
+    bio: ""
     # Il tuo lavoro
-    job: 
+    job: ""


### PR DESCRIPTION
The `it-IT.yml` file (#375) causes an error when starting Hexo server:

```
ERROR Process failed: languages/it-IT.yml
  TypeError: Cannot convert undefined or null to object
```

This commit fixes this by adding empty strings instead of missing values in the language file.