### PR TITLE
Remove search form when Algolia search is not enabled

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -33,7 +33,9 @@
             <% } %>
         </div>
         <%- partial('_partial/about', null, {cache: !config.relative_link}) %>
-        <%- partial('_partial/search', null, {cache: true}) %>
+        <% if (config.algolia) { %>
+            <%- partial('_partial/search', null, {cache: true}) %>
+        <% } %>
         <%- partial('_partial/cover', null, {cache: !config.relative_link}) %>
         <%- partial('_partial/script', {post: page}) %>
     </body>


### PR DESCRIPTION
### Configuration

 - **Operating system with version** : Windows 7
 - **Node version** : 6.9.1
 - **Hexo version** : 3.2.2
 - **Hexo-cli version** : 1.0.2
 
### Changes proposed

The Algolia search form should not be added to the DOM if Algolia is not configured. It produces unnecessary code and slows down the loading time due to fetching the Algolia logo from an external server.