### PR TITLE
Adding querystring support in gallery url

### DIFF
--- a/layout/_partial/post/gallery.ejs
+++ b/layout/_partial/post/gallery.ejs
@@ -15,7 +15,7 @@
         <div class="image-gallery-photos <%= imageGalleryClass %>">
             <% photos.forEach(function(photo) { %>
             <%
-                var rPhoto = /([\w:\-\/._#]+)(?:\s+([\w:\-\/._#]+))*(?:\s*["|'](.+)["|'])*/;
+                var rPhoto = /([\w:\-\/._#?=]+)(?:\s+([\w:\-\/._#?=]+))*(?:\s*["|'](.+)["|'])*/;
                 var match = photo.match(rPhoto);
                 photo = {
                     title: match[3] || '',


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : MacOS Sierra 10.12.5
 - **Node version** : v8.1.0
 - **Hexo version** : 3.3.7
 - **Hexo-cli version** : 1.0.3
 
### Changes proposed

 - gallery image url support querystring

