### PR TITLE
Update jquery to 2.2.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,8 +14,8 @@
         "tests"
     ],
     "dependencies": {
-        "fontawesome": "~4.6.0",
-        "jquery": "~2.1.3",
-        "fancybox": "~2.1.5"
+        "fontawesome": "~4.7.0",
+        "jquery": "~2.2.4",
+        "fancybox": "~2.1.6"
     }
 }


### PR DESCRIPTION
### Changes proposed

 - Use the latest version of jQuery 2.x (Closes #450)
 - Use the latest version of Font Awesome (Closes #452)
 - Use the latest version of fancybox 2 (Closes #453)