### PR TITLE
Sort all-tags and all-categories page's posts by descending date

### DIFF
--- a/layout/all-categories.ejs
+++ b/layout/all-categories.ejs
@@ -28,7 +28,7 @@ function displayCategoriesAndPosts(category) {
     html += '</h4>';
     html += '<ul class="archive-posts">';
     // create html for its posts
-    posts.forEach(function(post) {
+    posts.sort('date', 'desc').forEach(function(post) {
         html += '<li class="archive-post">';
         html += '<a class="archive-post-title" href="' + url_for(post.path) + '">';
         html += post.title || '(' + __('post.no_title') + ')';

--- a/layout/all-tags.ejs
+++ b/layout/all-tags.ejs
@@ -23,7 +23,7 @@
                     </a>
                 </h4>
                 <ul class="archive-posts">
-                    <% site.tags.findOne({'name': tag.name}).posts.each(function(post) { %>
+                    <% site.tags.findOne({'name': tag.name}).posts.sort('date', 'desc').each(function(post) { %>
                         <li class="archive-post">
                             <a class="archive-post-title" href="<%- url_for(post.path) %>">
                                 <%= post.title || '(' + __('post.no_title') + ')' %>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** :  Windows10 15063
 - **Node version** : 6.11.1
 - **Hexo version** : 3.4.1
 - **Hexo-cli version** : 1.0.4
 
### Changes proposed

A tags page and category page's post order are random.
Change the order of them to descending by post date.

Please see below screen shot.
 
### Before

![date](https://user-images.githubusercontent.com/11273093/32947384-f62a28dc-cbde-11e7-8666-72ac8342d0ca.png)

### After

![date-descending](https://user-images.githubusercontent.com/11273093/32947386-f8e088aa-cbde-11e7-879b-35e37c68fca7.png)