### PR TITLE
Add 404 page template for extensibility

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -553,6 +553,7 @@ Hide post meta, actions and comments using front-matter settings:
 
 ``` yaml
 title: Page not found
+layout: 404
 meta: false
 actions: false
 comments: false

--- a/layout/404.ejs
+++ b/layout/404.ejs
@@ -1,0 +1,1 @@
+<%- partial('_partial/post', {post: page}) %>


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : Windows 7 64bit
 - **Node version** : 6.11.4
 - **Hexo version** : 3.3.9
 - **Hexo-cli version** : 1.0.3
 
### Changes proposed

 - Adding a default ejs template for 404 page is necessary when it comes to 404 customization like adding redirect js code for multi-language 404 pages.
