### PR TITLE
Fix li.p margin

### DIFF
--- a/source/_css/components/_post.scss
+++ b/source/_css/components/_post.scss
@@ -42,9 +42,14 @@
             width:     auto;
             max-width: 100%;
         }
-        :not(blockquote):not(.alert) {
+        :not(blockquote):not(li):not(.alert) {
             & > p {
                 margin: 1.5em 0 0 0;
+            }
+        }
+        li {
+            p {
+                margin: 0 0 0 0;
             }
         }
     }


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : Windows 7 64bit
 - **Node version** : v6.11.4
 - **Hexo version** : 3.3.9
 - **Hexo-cli version** : 1.0.3
 
### Changes proposed

The default behaviour of Markdown is to wrap the list items in <p> tags if list items are separated by blank lines, this leads to an annoying margin in this theme. Change to remove it.

![snipaste_20180129_144524](https://user-images.githubusercontent.com/7401846/35509806-9c0f5300-0530-11e8-9ae2-6572952758e4.jpg)
