### PR TITLE
Delete npm run command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "A gorgeous responsive theme for Hexo blog framework",
   "main": "Gruntfile.js",
   "scripts": {
-    "start": "npm run grunt -- default",
-    "build": "npm run prod",
-    "prod": "npm run grunt -- buildProd",
+    "start": "grunt -- default",
+    "build": "prod",
+    "prod": "grunt -- buildProd",
     "grunt": "./node_modules/grunt-cli/bin/grunt",
     "lint": "./node_modules/eslint/bin/eslint.js .",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** :  Windows 10
 - **Node version** :  v8.9.2
 - **npm version** :  v5.5.1
 - **Hexo version** :  v3.4.2
 - **Hexo-cli version** :  v1.0.4
 - **Tranquilpeak version** : v2.0.0
 
### Changes proposed

 - Delete `npm run` command in package.json

### Reason

On Windows got below errors when execute `npm run start` or `npm run prod` .

```
> ./node_modules/grunt-cli/bin/grunt "buildProd"

'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! hexo-theme-tranquilpeak@2.0.0 grunt: `./node_modules/grunt-cli/bin/grunt "buildProd"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the hexo-theme-tranquilpeak@2.0.0 grunt script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\YoshinoriN\AppData\Roaming\npm-cache\_logs\2018-03-24T14_15_11_371Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! hexo-theme-tranquilpeak@2.0.0 prod: `npm run grunt -- buildProd`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the hexo-theme-tranquilpeak@2.0.0 prod script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\YoshinoriN\AppData\Roaming\npm-cache\_logs\2018-03-24T14_15_11_398Z-debug.log
```

I think this problem relate below issue.

> [npm on windows can't run scripts with ".", relative paths "../"](https://github.com/npm/npm/issues/13789)

### NOTICE

Sorry, I confirm work well it on Windows. I doesn't try other platform.