### PR TITLE
Sort all-categories by category name

### DIFF
--- a/layout/all-categories.ejs
+++ b/layout/all-categories.ejs
@@ -40,7 +40,7 @@ function displayCategoriesAndPosts(category) {
     });
     if (childCategories.length > 0) {
         // recursive iteration on its child categories
-        childCategories.forEach(function(childCategory) {
+        childCategories.sort('name', 'asc').forEach(function(childCategory) {
             // clone parents of current category to its child category
             childCategory.parents = category.parents.slice();
             // add current category to the parent of current child category
@@ -80,7 +80,7 @@ function displayCategories(category) {
     if (childCategories.length > 0) {
         html += '<ul style="margin-bottom:0;">';
         // recursive iteration on its child categories
-        childCategories.forEach(function(childCategory) {
+        childCategories.sort('name', 'asc').forEach(function(childCategory) {
             // clone parents of current category to its child category
             childCategory.parents = category.parents.slice();
             // add current category to the parent of current child category


### PR DESCRIPTION
### Configuration

 - **Operating system with version** : Windows10 17134
 - **Node version** : 8.11.3
 - **Hexo version** : 3.7.1
 - **Hexo-cli version** : 1.1.0
 
### Changes proposed

Currently all-categories page's categories order are random (?).
Change the order of them to ascending by category name.
