### PR TITLE
Enabled windows execution of npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run grunt -- default",
     "build": "npm run prod",
     "prod": "npm run grunt -- buildProd",
-    "grunt": "./node_modules/grunt-cli/bin/grunt",
+    "grunt": "node ./node_modules/grunt-cli/bin/grunt",
     "lint": "./node_modules/eslint/bin/eslint.js .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run prod",
     "prod": "npm run grunt -- buildProd",
     "grunt": "node ./node_modules/grunt-cli/bin/grunt",
-    "lint": "./node_modules/eslint/bin/eslint.js .",
+    "lint": "node ./node_modules/eslint/bin/eslint.js .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
By adding the node prefix to the line, windows users can now properly execute the start script

<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** :  Windows with latest theme release
 - **Node version** :  latest
 - **Hexo version** :  latest
 - **Hexo-cli version** :  latest
 
### Changes proposed

 - Adding "node" to line 10 of the package json, that way windows users can execute the scripts from bash terminals.
