### PR TITLE
Changes to thumbnail image

### DIFF
--- a/source/_css/components/_postShorten.scss
+++ b/source/_css/components/_postShorten.scss
@@ -17,6 +17,10 @@
 
     .postShorten-thumbnailimg {
         overflow:hidden;
+
+        img{
+           border-radius: 5px;
+        }
     }
     .postShorten-header {
         .postShorten-title {

--- a/source/_css/components/_postShorten.scss
+++ b/source/_css/components/_postShorten.scss
@@ -17,10 +17,6 @@
 
     .postShorten-thumbnailimg {
         overflow:hidden;
-
-        img{
-           border-radius: 5px;
-        }
     }
     .postShorten-header {
         .postShorten-title {
@@ -154,7 +150,7 @@
             img {
                 width:      100%;
                 height:     auto;
-                max-height: $post-thumbnail-image-max-height;
+                max-height: $post-bottom-thumbnail-image-max-height;
                 object-fit: cover;
             }
         }

--- a/source/_css/components/_postShorten.scss
+++ b/source/_css/components/_postShorten.scss
@@ -148,8 +148,10 @@
             margin:   15px 0 15px 0;
 
             img {
-                width:  auto;
-                height: auto;
+                width:      100%;
+                height:     auto;
+                max-height: $post-thumbnail-image-max-height;
+                object-fit: cover;
             }
         }
     }

--- a/source/_css/utils/_variables.scss
+++ b/source/_css/utils/_variables.scss
@@ -244,6 +244,7 @@ $pagination-height: 60px;
 // Post thumbnail image
 // Width and height of post's thumbnail image
 $post-thumbnail-image-width: 140px;
+$post-thumbnail-image-max-height: 250px;
 
 // Tooltip
 $tooltip: (

--- a/source/_css/utils/_variables.scss
+++ b/source/_css/utils/_variables.scss
@@ -244,7 +244,7 @@ $pagination-height: 60px;
 // Post thumbnail image
 // Width and height of post's thumbnail image
 $post-thumbnail-image-width: 140px;
-$post-thumbnail-image-max-height: 250px;
+$post-bottom-thumbnail-image-max-height: 250px;
 
 // Tooltip
 $tooltip: (


### PR DESCRIPTION
<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** :  Windows 10
 - **Node version** :   8.11.2
 - **Hexo version** :  3.7.1
 - **Hexo-cli version** :  1.1.0
 
### Changes proposed

 - Auto resize for bottom thumbnail image
 - Add border-radius to thumbnail image


## Before
E.g. Bottom thumbnail image width = 2048px. Width of the page is 750px.
![before-large](https://user-images.githubusercontent.com/40011055/47736935-b8561380-dcaa-11e8-9beb-2b3f6412ed52.jpg)
Thumbnail image didn't auto resize to show full image.

## After
Now it can resize according to page's width. Max-height attribute is added.
![3ok](https://user-images.githubusercontent.com/40011055/47737104-1a167d80-dcab-11e8-9a09-22147093ddc8.jpg)


I also add border-radius = 5px for thumbnail image to make it looks more comfortable.
![4x](https://user-images.githubusercontent.com/40011055/47737350-ad4fb300-dcab-11e8-92cb-eca9cc4d0717.jpg)
