### PR TITLE
Corrected Algolia Icon In Search

### DIFF
--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -4,7 +4,7 @@
             <span class="close-button"><i class="fa fa-times"></i></span>
             <a href="https://algolia.com" target="_blank" rel="noopener" class="searchby-algolia text-color-light link-unstyled">
                 <span class="searchby-algolia-text text-color-light text-small">by</span>
-                <img class="searchby-algolia-logo" src="https://www.algolia.com/static_assets/images/press/downloads/algolia-light.svg">
+                <img class="searchby-algolia-logo" src="https://www.algolia.com/static/algolia-blue-mark-d9c78960c0c19f25f2dc0614236bff90.png">
             </a>
             <i class="search-icon fa fa-search"></i>
             <form id="algolia-search-form">


### PR DESCRIPTION
The previous SVG is no longer hosted by algolia, and the png i've added is from their official marketing resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/542)
<!-- Reviewable:end -->
