### PR TITLE
Clicking outside of about card dismisses card

### DIFF
--- a/source/_css/layouts/_about.scss
+++ b/source/_css/layouts/_about.scss
@@ -10,6 +10,7 @@
     line-height: 100%;
     overflow-y:  auto;
     overflow-x:  hidden;
+    cursor:      pointer;
     z-index:     map-get($z-indexes, l-about);
 
     #about-card {
@@ -22,6 +23,7 @@
         margin:        15px auto;
         border-radius: 3px;
         padding:       30px 0;
+        cursor:        default;
         @include prefix(box-shadow, 0 0 5px rgba(0, 0, 0, 0.50), 'webkit' 'moz');
 
         #about-btn-close {

--- a/source/_css/layouts/_about.scss
+++ b/source/_css/layouts/_about.scss
@@ -23,7 +23,7 @@
         margin:        15px auto;
         border-radius: 3px;
         padding:       30px 0;
-        cursor:        default;
+        cursor:        initial;
         @include prefix(box-shadow, 0 0 5px rgba(0, 0, 0, 0.50), 'webkit' 'moz');
 
         #about-btn-close {

--- a/source/_js/about.js
+++ b/source/_js/about.js
@@ -33,6 +33,11 @@
         e.preventDefault();
         self.playBack();
       });
+      // Detect click on close button outside of card
+      self.$about.click(function(e) {
+        e.preventDefault();
+        self.playBack();
+      });
     },
 
     /**

--- a/source/_js/about.js
+++ b/source/_js/about.js
@@ -38,6 +38,10 @@
         e.preventDefault();
         self.playBack();
       });
+      // Deny closing the about page when users click on the card
+      self.$aboutCard.click(function(event) {
+        event.stopPropagation();
+      });
     },
 
     /**


### PR DESCRIPTION
This is currently how I have my site configured, and seemed to be the preferred / instinctive way to interact with the card. On desktop, most people clicked outside of the card hoping it would dismiss, and then spent time searching for the X button, or attempting to go backwards in the browser, navigating away from the page entirely,

Implementation live for example on https://www.benmitchinson.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/547)
<!-- Reviewable:end -->
