### PR TITLE
Added Aria-Label to image links in index page for improved accessibility

### DIFF
--- a/layout/_partial/index.ejs
+++ b/layout/_partial/index.ejs
@@ -31,9 +31,9 @@
     <article class="postShorten postShorten--thumbnailimg-<%= thumbnailImagePosition %>">
         <div class="postShorten-wrap">
             <% if (thumbnailImageUrl !== null && thumbnailImagePosition === "top") { %>
-                <a href="<%- url_for(post.path) %>">
+                <a href="<%- url_for(post.path) %>" aria-label="<%= post.title %>">
                     <div class="postShorten-thumbnailimg">
-                        <img alt="" src="<%= thumbnailImageUrl %>"/>
+                        <img alt="<%= post.title %>" src="<%= thumbnailImageUrl %>"/>
                     </div>
                 </a>
                 <% thumbnailImageUrl = null; %>

--- a/layout/_partial/index.ejs
+++ b/layout/_partial/index.ejs
@@ -31,9 +31,9 @@
     <article class="postShorten postShorten--thumbnailimg-<%= thumbnailImagePosition %>">
         <div class="postShorten-wrap">
             <% if (thumbnailImageUrl !== null && thumbnailImagePosition === "top") { %>
-                <a href="<%- url_for(post.path) %>" aria-label="<%= post.title %>">
+                <a href="<%- url_for(post.path) %>" aria-label="Open the article: <%= post.title %>">
                     <div class="postShorten-thumbnailimg">
-                        <img alt="<%= post.title %>" src="<%= thumbnailImageUrl %>"/>
+                        <img alt="Thumbnail image of the article: <%= post.title %>" src="<%= thumbnailImageUrl %>"/>
                     </div>
                 </a>
                 <% thumbnailImageUrl = null; %>


### PR DESCRIPTION
### Changes proposed
Inserting the relative post title as a string in Aria-Label tags and image alt parameters for redirects. This is an accessibility standard best [documented here](https://dequeuniversity.com/rules/axe/3.2/link-name).

Including this change bumped my [Lighthouse audit](https://web.dev/measure) accessibility score by 15, meaning tranquilpeak now scores above 90 by default when using the theme. I feel anything we can include in the theme itself to increase accessibility is a plus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/548)
<!-- Reviewable:end -->
