### PR TITLE
Minor optimization: Use font-display auto

### DIFF
--- a/source/_css/utils/_fonts.scss
+++ b/source/_css/utils/_fonts.scss
@@ -2,6 +2,7 @@
     font-family: 'Open Sans';
     font-style:  normal;
     font-weight: 400;
+    font-display: auto;
     src:         local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v10/cJZKeOuBrn4kERxqtaUH3SZ2oysoEQEeKwjgmXLRnTc.ttf) format('truetype');
 }
 
@@ -9,6 +10,7 @@
     font-family: 'Open Sans';
     font-style:  normal;
     font-weight: 700;
+    font-display: auto;
     src:         local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v10/k3k702ZOKiLJc3WVjuplzJS3E-kSBmtLoNJPDtbj2Pk.ttf) format('truetype');
 }
 
@@ -16,6 +18,7 @@
     font-family: 'Merriweather';
     font-style:  normal;
     font-weight: 300;
+    font-display: auto;
     src:         local('Merriweather Light'), local('Merriweather-Light'), url(https://fonts.gstatic.com/s/merriweather/v8/ZvcMqxEwPfh2qDWBPxn6nk7nEl83IKQRaQwpv_tz1Eg.ttf) format('truetype');
 }
 
@@ -23,6 +26,7 @@
     font-family: 'Merriweather';
     font-style:  normal;
     font-weight: 400;
+    font-display: auto;
     src:         local('Merriweather'), url(https://fonts.gstatic.com/s/merriweather/v8/RFda8w1V0eDZheqfcyQ4EJS3E-kSBmtLoNJPDtbj2Pk.ttf) format('truetype');
 }
 
@@ -30,6 +34,7 @@
     font-family: 'Merriweather';
     font-style:  normal;
     font-weight: 700;
+    font-display: auto;
     src:         local('Merriweather Bold'), local('Merriweather-Bold'), url(https://fonts.gstatic.com/s/merriweather/v8/ZvcMqxEwPfh2qDWBPxn6nv83cGrqhiQgWmjXfohD0fc.ttf) format('truetype');
 }
 
@@ -37,6 +42,7 @@
     font-family: 'Merriweather';
     font-style:  italic;
     font-weight: 300;
+    font-display: auto;
     src:         local('Merriweather Light Italic'), local('Merriweather-LightItalic'), url(https://fonts.gstatic.com/s/merriweather/v8/EYh7Vl4ywhowqULgRdYwIGrKw6K5wsYdxr6rUL2ZGaM.ttf) format('truetype');
 }
 
@@ -44,5 +50,6 @@
     font-family: 'Merriweather';
     font-style:  italic;
     font-weight: 700;
+    font-display: auto;
     src:         local('Merriweather Bold Italic'), local('Merriweather-BoldItalic'), url(https://fonts.gstatic.com/s/merriweather/v8/EYh7Vl4ywhowqULgRdYwII1kRdeHIFWYEsp6A2f99b0.ttf) format('truetype');
 }


### PR DESCRIPTION
To help with font performance, google recommends using `font-display: auto` as per: https://developers.google.com/web/updates/2016/02/font-display

This small PR implements that change to all of the current `@font-face` rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/550)
<!-- Reviewable:end -->
