### PR TITLE
Update README to include gitalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A gorgeous responsive theme for Hexo blog framework
 - Algolia
 - Facebook Insights
 - Gitment
+- Gitalk
  
 ## Quick start
 


### PR DESCRIPTION
### Related issues: https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/pull/533

### Changes

Recently Gitalk was added as a comment provider. I totally forgot to update the readme with Gitalk.

### Testing guide
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/556)
<!-- Reviewable:end -->
