### PR TITLE
Added partial for Google analytics opt-out

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -183,6 +183,15 @@ Follow these steps, to add new filter :
 7. Select **Custom filter**, **Filter Field** : `Hostname`, **Filter Pattern** :  `(.*?localhost.*?)`
 8. Click on **Save** button
 
+#### Configure optout evaluation
+
+When setting the following setting to true and with having `google_analytics_id` set, your site will disable tracking, if the official optout cookie is set. This is required e.g. in the EU by the Cookie Directive. This also give you the possibility to add a required opt-out function to your privacy policy by using the gaOptout() js function, available when you activate this setting.
+
+```yaml
+google_analytics_optout:
+    enable: true
+```
+
 ## Modifying the theme
 
 1. Run `npm install` to install dependencies

--- a/_config.yml
+++ b/_config.yml
@@ -237,6 +237,9 @@ gitalk:
 
 # Your Google analystics web property ID : UA-XXXXX-X
 google_analytics_id:
+# Integrate Google analytics optout into your site to disable tracking if the opt-out cookie exists. Requires google_analytics_id to be set.
+google_analytics_optout:
+    enable: true
 # Your Baidu analystics web property ID : 9505a5af654a2478f93fd6c0ae4f687d
 baidu_analytics_id:
 # Your Gravatar email. Overwrite `author.picture` everywhere in the blog

--- a/layout/_partial/google-analytics-optout.ejs
+++ b/layout/_partial/google-analytics-optout.ejs
@@ -1,0 +1,16 @@
+<% if (theme.google_analytics_optout.enable) { %>
+<script type="text/javascript">
+    var gaProperty = '<%= theme.google_analytics_id %>';
+
+    var disableStr = 'ga-disable-' + gaProperty;
+    if (document.cookie.indexOf(disableStr + '=true') > -1) {
+        window[disableStr] = true;
+    }
+
+    // Opt-out function
+    function gaOptout() {
+        document.cookie = disableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+        window[disableStr] = true;
+    }
+</script>
+<% } %>


### PR DESCRIPTION
### Related issues: No issue
### Changes
Added a partial to be privacy compliant and disable google analytics tracking, if optout cookie is set. Also provides the possibility to use the gaOptout() function in your posts. This is helpful to satisfy requirements e.g. by GDPR to provide an optout possibility in your privacy settings.


### Testing guide
Set the google_analytics_id property in _config and set google_analytics_optout.enable to true.
Add the `<%- partial('google-analytics-optout') %>` part to head.ejs and check, if tracking still works with optout cookie set.

<!-- IMPORTANT: Make sure you've done all the things listed below before creating a pull request --> 
### Checklist
- [X] I checked the code style with `npm run lint` 
- [X] I updated the README or the documentation <!-- if applicable -->
- [X] I tested my changes with the current recommended Node LTS version: 8.4.0
- [X] I tested my changes on all desktop browsers listed below (with their latest versions): 
  - [X] Chrome, Firefox and Opera
  - [X] Safari
  - [x] Edge
  - [x] IE 10+
- [x] I tested my changes on all mobile browsers listed below (with their latest versions): 
  - [X] Firefox
  - [X] Safari
  - [x] Edge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/559)
<!-- Reviewable:end -->
