### PR TITLE
enhancement: update default time format in zh-cn.yml and zh-tw.yml

### DIFF
--- a/languages/zh-cn.yml
+++ b/languages/zh-cn.yml
@@ -1,5 +1,5 @@
 # 在所有地方显示的日期格式
-date_format: "YYYY 年 MM 月 DD 日"
+date_format: "YYYY 年 M 月 D 日"
 
 global:
     home: "首页"

--- a/languages/zh-cn.yml
+++ b/languages/zh-cn.yml
@@ -1,5 +1,5 @@
-# 在所有地方显示的 date 格式化
-date_format: "MMM DD, YYYY"
+# 在所有地方显示的日期格式
+date_format: "YYYY 年 MM 月 DD 日"
 
 global:
     home: "首页"

--- a/languages/zh-tw.yml
+++ b/languages/zh-tw.yml
@@ -1,5 +1,5 @@
-# 在所有地方顯示的 date 格式
-date_format: "MMM DD, YYYY"
+# 在所有地方顯示的日期格式
+date_format: "YYYY 年 MM 月 DD 日"
 
 global:
     home: "首頁"

--- a/languages/zh-tw.yml
+++ b/languages/zh-tw.yml
@@ -1,5 +1,5 @@
 # 在所有地方顯示的日期格式
-date_format: "YYYY 年 MM 月 DD 日"
+date_format: "YYYY 年 M 月 D 日"
 
 global:
     home: "首頁"


### PR DESCRIPTION
- In China, the time format used by most people is YYYY/MM/DD(YYYY 年 MM 月 DD 日).

### Related issues: <!-- Reference any related issues. E.g: #4515 (if applicable) --> 
### Changes
Update default time format(``MMM DD, YYYY`` -> ``YYYY 年 M 月 D 日``)

- before
![before](https://user-images.githubusercontent.com/55020690/210467682-1517af5d-1833-470a-ae40-0c21abe59d5a.png)


- after
![after](https://user-images.githubusercontent.com/55020690/211182008-99ba17de-84ed-4de4-b1d4-b06af965ee58.png)



### Testing guide
<!-- Describe the steps to test the changes proposed. --> 


<!-- IMPORTANT: Make sure you've done all the things listed below before creating a pull request --> 
### Checklist
- [x] I checked the code style with `npm run lint` 
- [ ] I updated the README or the documentation <!-- if applicable -->
- [x] I tested my changes with the current recommended Node LTS version: 16.14.1<!-- Specify the version you used -->
- [x] I tested my changes on all desktop browsers listed below (with their latest versions): <!-- if applicable -->
  - [x] Chrome, Firefox and Opera
  - [ ] Safari
  - [x] Edge
  - [x] IE 10+
- [x] I tested my changes on all mobile browsers listed below (with their latest versions): <!-- if applicable -->
  - [x] Chrome, Firefox and Opera
  - [x] Safari
  - [x] Edge

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-theme-tranquilpeak/711)
<!-- Reviewable:end -->
